### PR TITLE
[STEP 04] 동일 사용자의 중복 수강신청 기능 통합테스트 추가

### DIFF
--- a/src/test/java/com/hanghae99plus/duhee/lecture_application/integrationtest/interfaces/api/lecture/LectureConcurrentTest.java
+++ b/src/test/java/com/hanghae99plus/duhee/lecture_application/integrationtest/interfaces/api/lecture/LectureConcurrentTest.java
@@ -3,6 +3,8 @@ package com.hanghae99plus.duhee.lecture_application.integrationtest.interfaces.a
 import com.hanghae99plus.duhee.lecture_application.domain.lecture.LectureEntity;
 import com.hanghae99plus.duhee.lecture_application.LectureApplication;
 import com.hanghae99plus.duhee.lecture_application.domain.lecture.LectureRepository;
+import com.hanghae99plus.duhee.lecture_application.domain.lecture.UserLectureEnrollmentEntity;
+import com.hanghae99plus.duhee.lecture_application.domain.lecture.UserLectureEnrollmentRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,6 +15,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -30,6 +33,9 @@ public class LectureConcurrentTest {
 
     @Autowired
     private LectureRepository lectureRepository;
+
+    @Autowired
+    private UserLectureEnrollmentRepository userLectureEnrollmentRepository;
 
     private MockMvc mockMvc;
 
@@ -76,5 +82,37 @@ public class LectureConcurrentTest {
 
         LectureEntity lectureEntity = lectureRepository.findById(1L).orElseThrow();
         assertEquals(30, lectureEntity.getCurrentEnrollment());
+    }
+
+    @Test
+    public void 동일한_유저정보로_동시에_5번의_같은_강의_수강신청시_1번만_성공해야한다() throws InterruptedException {
+        int numberOfThreads = 5;
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+
+        for (int i = 1; i <= numberOfThreads; i++) {
+            int user_id = 1;
+            executorService.execute(() -> {
+                try {
+                    mockMvc.perform(post("/lectures/1/enrollments")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(String.valueOf(user_id)))
+                            .andExpect(status().isOk());
+                } catch (Exception e) {
+                    e.printStackTrace();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executorService.shutdown();
+
+        LectureEntity lectureEntity = lectureRepository.findById(1L).orElseThrow();
+        assertEquals(1, lectureEntity.getCurrentEnrollment());
+        List<UserLectureEnrollmentEntity> lectureEntitiesByUserId = userLectureEnrollmentRepository.findByUserId(1L);
+        assertEquals(1, lectureEntitiesByUserId.size());
+        assertEquals(1L, lectureEntitiesByUserId.get(0).getLectureId());
     }
 }


### PR DESCRIPTION
### **커밋 링크**
<!-- 
좋은 피드백을 받기 위해 가장 중요한 것은 코드를 작성할 때 커밋을 작업 단위로 잘 쪼개는 것입니다.
모든 작업을 하나의 커밋에 진행하고 PR을 하면 구조 파악에 많은 시간을 소모하기 때문에 절대로
좋은 피드백을 받을 수 없습니다.


필수 양식)
커밋 이름 : 커밋 링크

예시)
동시성 처리 : c83845
동시성 테스트 코드 : d93ji3
-->

동일 사용자의 중복 수강신청 통합테스트 구현 : 1ebdec445491154ac13b204113752e0c77f937f4
(이전 PR https://github.com/Diocto/02-lecture-application/pull/2 로 인해 중복신청 기능을 막는 기능은 구현되어있습니다)

---
### **리뷰 포인트(질문)**
- 리뷰 포인트 1
이전 리뷰에서 동시성 테스트의 경우 동시성이 발생하는 상황을 구체적으로 만들어 놓고, 무조건 동시성 상황이 발생하는 테스트 환경을 만들어 놓은 상태에서 테스트를 작성하는게 바람직하다고 피드백 받았습니다. 그런데 실질적으로 구현하려고 하니 실제 비즈니스 로직이 들어가 있는 레이어 등을 손을 봐야하는지 아니면 다른 좋은 방법이 있는제 구체적으로 감이 잘 잡히지 않습니다.
현재 테스트 수준이 기능 검증 수준에서 적당한 수준인지, 아니면 더 좋은 방법이 있는지 궁금합니다.

- 리뷰 포인트 2
<!-- - 리뷰어가 특히 확인해야 할 부분이나 신경 써야 할 코드가 있다면 명확히 작성해주세요.(최대 2개)
  
  좋은 예:
  - `ErrorMessage` 컴포넌트의 상태 업데이트 로직이 적절한지 검토 부탁드립니다.
  - 추가한 유닛 테스트(`LoginError.test.js`)의 테스트 케이스가 충분한지 확인 부탁드립니다.

  나쁜 예:
  - 개선사항을 알려주세요.
  - 코드 전반적으로 봐주세요.
  - 뭘 질문할지 모르겠어요. -->
---